### PR TITLE
Stop remote thread after interrupt.

### DIFF
--- a/installer/include_versions.iss
+++ b/installer/include_versions.iss
@@ -1,4 +1,4 @@
 [Files]
 
 #define BUILDNUMBER "1"
-#define VERSIONNUMBER "v1.8.1"
+#define VERSIONNUMBER "v1.8.2"

--- a/release.cpp
+++ b/release.cpp
@@ -19,5 +19,5 @@
 //====================================================================
 
 const char* release = "GateHouse A/S (C) Uniproxy";
-const char* version = "1.8.1";
+const char* version = "1.8.2";
 

--- a/src/remoteclient.h
+++ b/src/remoteclient.h
@@ -47,7 +47,7 @@ public:
    void stop();
 
    // When terminating these threads e.g. due to lost connections, just leave them as zoombies
-   // Clean up will be done when starting new threads
+   // Clean up will be done when starting new threads or when checking deadline.
    void local_threadproc();
    void remote_threadproc();
    
@@ -80,6 +80,16 @@ public:
       return this->m_stopped;
    }
 
+   bool is_thread_active() const
+   {
+      if (this->thread_ended == std::chrono::system_clock::time_point())
+      {
+         return true;
+      }
+      // Wait 2 seconds after end of thread before we stop it.
+      return std::chrono::system_clock::now() - this->thread_ended < std::chrono::seconds(2);
+   }
+
 protected:
 
    void interrupt(bool synced);
@@ -94,6 +104,7 @@ protected:
    boost::asio::io_service& m_io_service;
 
    std::chrono::system_clock::time_point m_stopped = std::chrono::system_clock::time_point();
+   std::chrono::system_clock::time_point thread_ended = std::chrono::system_clock::time_point();
 
    RemoteProxyHost &m_host;
 };


### PR DESCRIPTION
Added timer for when an interrupt happens, and the end of remote_threadproc is reached. During deadline check, the system nok looks for this timer, and if it's set and is over a given threshold, then stop and erase the thread.